### PR TITLE
Feat/link header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,19 +6,42 @@ import { ConfirmPresenca } from "./components/form/Presenca";
 import { GiftProvider } from "./context/ItensContext";
 import { Location } from "./components/Location";
 import { ToastContainer } from "react-toastify";
+import { useRef } from "react";
 
+export type SectionSelected = "location" | "gifts" | "confirm-presenca";
 function App() {
+  const sectionRefs = {
+    location: useRef<HTMLDivElement>(null),
+    gifts: useRef<HTMLDivElement>(null),
+    "confirm-presenca": useRef<HTMLDivElement>(null),
+  };
+
+  const handleMenuClick = (section: SectionSelected) => {
+    const ref = sectionRefs[section];
+    ref.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+      inline: "nearest",
+    });
+  };
+
   return (
     <main className="flex size-full flex-col gap-20 !antialiased">
       <div className="flex h-screen max-h-screen w-full flex-col bg-zinc-900/50 bg-[url('/images/bg-hero.jpg')] bg-cover bg-fixed bg-center bg-no-repeat bg-blend-overlay">
-        <Header />
+        <Header onMenuClick={handleMenuClick}/>
         <Home />
       </div>
-      <Location />
-      <GiftProvider>
-        <ListItens />
-      </GiftProvider>
-      <ConfirmPresenca />
+      <div ref={sectionRefs.location}>
+        <Location />
+      </div>
+      <div ref={sectionRefs.gifts}>
+        <GiftProvider>
+          <ListItens />
+        </GiftProvider>
+      </div>
+      <div ref={sectionRefs["confirm-presenca"]}>
+        <ConfirmPresenca />
+      </div>
       <ToastContainer
         position="top-center"
         autoClose={5000}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
   return (
     <main className="flex size-full flex-col gap-20 !antialiased">
       <div className="flex h-screen max-h-screen w-full flex-col bg-zinc-900/50 bg-[url('/images/bg-hero.jpg')] bg-cover bg-fixed bg-center bg-no-repeat bg-blend-overlay">
-        <Header onMenuClick={handleMenuClick}/>
+        <Header onMenuClick={handleMenuClick} />
         <Home />
       </div>
       <div ref={sectionRefs.location}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,16 +1,26 @@
+import { SectionSelected } from "../App";
 import MenuIcon from "./MenuIcon";
 
-export function Header() {
+interface HeaderProps {
+  onMenuClick?: (props: SectionSelected) => void;
+}
+export function Header({onMenuClick }: HeaderProps) {
+
+  const handleMenuClick = (section: SectionSelected) => {
+    if (onMenuClick) {
+      onMenuClick(section);
+    }
+  };
   return (
     <header className="z-50 mt-10 flex min-w-full max-w-[1360px] justify-end gap-8 p-2 px-5  font-medium lg:justify-center">
       <div className="hidden gap-20 lg:flex">
-        <nav className="h-12 w-72  cursor-pointer  content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80">
+        <nav className="h-12 w-72  cursor-pointer  content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80" onClick={() => handleMenuClick("location")}>
           Cerimônia
         </nav>
-        <nav className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80">
+        <nav className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80" onClick={() => handleMenuClick("gifts")}>
           Lista de presentes
         </nav>
-        <nav className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80">
+        <nav className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80" onClick={() => handleMenuClick("confirm-presenca")}>
           Confirme sua presença
         </nav>
       </div>
@@ -21,13 +31,13 @@ export function Header() {
         </div>
         <div className="absolute right-0 hidden pt-5 group-hover:block">
           <div className="flex w-56 flex-col gap-2 rounded-lg bg-zinc-700 p-2 text-center">
-            <nav className="h-8  cursor-pointer content-center rounded-lg text-center text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl">
+            <nav className="h-8  cursor-pointer content-center rounded-lg text-center text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl" onClick={() => handleMenuClick("location")}>
               Cerimônia
             </nav>
-            <nav className="h-8  cursor-pointer content-center rounded-lg text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl">
+            <nav className="h-8  cursor-pointer content-center rounded-lg text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl" onClick={() => handleMenuClick("gifts")}>
               Presentes
             </nav>
-            <nav className="h-8 w-full cursor-pointer content-center rounded-lg text-lg font-semibold  leading-5 ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl">
+            <nav className="h-8 w-full cursor-pointer content-center rounded-lg text-lg font-semibold  leading-5 ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl" onClick={() => handleMenuClick("confirm-presenca")}>
               Presença
             </nav>
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,8 +4,7 @@ import MenuIcon from "./MenuIcon";
 interface HeaderProps {
   onMenuClick?: (props: SectionSelected) => void;
 }
-export function Header({onMenuClick }: HeaderProps) {
-
+export function Header({ onMenuClick }: HeaderProps) {
   const handleMenuClick = (section: SectionSelected) => {
     if (onMenuClick) {
       onMenuClick(section);
@@ -14,13 +13,22 @@ export function Header({onMenuClick }: HeaderProps) {
   return (
     <header className="z-50 mt-10 flex min-w-full max-w-[1360px] justify-end gap-8 p-2 px-5  font-medium lg:justify-center">
       <div className="hidden gap-20 lg:flex">
-        <nav className="h-12 w-72  cursor-pointer  content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80" onClick={() => handleMenuClick("location")}>
+        <nav
+          className="h-12 w-72  cursor-pointer  content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80"
+          onClick={() => handleMenuClick("location")}
+        >
           Cerimônia
         </nav>
-        <nav className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80" onClick={() => handleMenuClick("gifts")}>
+        <nav
+          className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80"
+          onClick={() => handleMenuClick("gifts")}
+        >
           Lista de presentes
         </nav>
-        <nav className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80" onClick={() => handleMenuClick("confirm-presenca")}>
+        <nav
+          className="h-12 w-72  cursor-pointer content-center rounded-lg bg-zinc-700/60  text-2xl font-semibold ease-in hover:opacity-80"
+          onClick={() => handleMenuClick("confirm-presenca")}
+        >
           Confirme sua presença
         </nav>
       </div>
@@ -31,13 +39,22 @@ export function Header({onMenuClick }: HeaderProps) {
         </div>
         <div className="absolute right-0 hidden pt-5 group-hover:block">
           <div className="flex w-56 flex-col gap-2 rounded-lg bg-zinc-700 p-2 text-center">
-            <nav className="h-8  cursor-pointer content-center rounded-lg text-center text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl" onClick={() => handleMenuClick("location")}>
+            <nav
+              className="h-8  cursor-pointer content-center rounded-lg text-center text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl"
+              onClick={() => handleMenuClick("location")}
+            >
               Cerimônia
             </nav>
-            <nav className="h-8  cursor-pointer content-center rounded-lg text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl" onClick={() => handleMenuClick("gifts")}>
+            <nav
+              className="h-8  cursor-pointer content-center rounded-lg text-lg font-semibold ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl"
+              onClick={() => handleMenuClick("gifts")}
+            >
               Presentes
             </nav>
-            <nav className="h-8 w-full cursor-pointer content-center rounded-lg text-lg font-semibold  leading-5 ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl" onClick={() => handleMenuClick("confirm-presenca")}>
+            <nav
+              className="h-8 w-full cursor-pointer content-center rounded-lg text-lg font-semibold  leading-5 ease-in hover:bg-zinc-600 mobile:h-12 mobile:text-xl"
+              onClick={() => handleMenuClick("confirm-presenca")}
+            >
               Presença
             </nav>
           </div>


### PR DESCRIPTION
This pull request introduces functionality to enable smooth scrolling to specific sections of the page when menu items are clicked. The changes involve adding section references, defining a new type for section identifiers, and updating the `Header` component to handle menu clicks.

### Smooth scrolling functionality:

* **Section references and scrolling logic:** Added `useRef` hooks for section elements in `src/App.tsx` and implemented the `handleMenuClick` function to scroll to the corresponding section when a menu item is clicked.

### Updates to `Header` component:

* **Prop for menu click handling:** Updated the `Header` component in `src/components/Header.tsx` to accept an optional `onMenuClick` prop, allowing it to trigger the scrolling logic in the parent component.
* **Menu item click handlers:** Added `onClick` handlers to each navigation item in the `Header` component to call the `handleMenuClick` function with the appropriate section identifier. This applies to both the main navigation bar and the dropdown menu. [[1]](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fR1-R31) [[2]](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL24-R57)