### PR TITLE
feat: replace email field with phone input and add phone number masking

### DIFF
--- a/src/components/form/Presenca.tsx
+++ b/src/components/form/Presenca.tsx
@@ -137,7 +137,7 @@ export function ConfirmPresenca() {
 
               <div className="flex w-full flex-col items-start justify-start gap-2">
                 <span className="text-start text-lg/3 font-semibold ">
-                  Telefone para contato{" "}
+                  Telefone para contato:{" "}
                 </span>
                 <input
                   className="h-12 w-full rounded-lg p-4 text-start outline-none placeholder:text-sm placeholder:uppercase focus:border focus:border-amber-400"

--- a/src/components/form/Presenca.tsx
+++ b/src/components/form/Presenca.tsx
@@ -13,7 +13,7 @@ interface Input {
 
 const validationFormSchema = zod.object({
   isGoToEvent: zod.enum(["1", "0"]),
-  email: zod.string().min(1).email(),
+  phone: zod.string().min(1),
   name: zod.string().min(1),
   adultCount: zod.number(),
   childCount: zod.number(),
@@ -31,7 +31,7 @@ export function ConfirmPresenca() {
   const { register, handleSubmit, watch, setValue } = useForm<FormData>({
     resolver: zodResolver(validationFormSchema),
     defaultValues: {
-      email: "",
+      phone: "",
       isGoToEvent: "1",
       name: "",
       adultCount: 1,
@@ -70,6 +70,8 @@ export function ConfirmPresenca() {
 
   async function handleSubimitForm(data: FormData) {
     setLoading(true);
+    data.phone = data.phone.replace(/\D/g, "");
+
     await saveFormData(data).then((res) => {
       if (res.status !== 201) {
         const { data } = res;
@@ -82,6 +84,19 @@ export function ConfirmPresenca() {
 
       setSuccess(true);
     });
+  }
+
+  function maskPhone(value: string) {
+    return value
+      .replace(/\D/g, "")
+      .replace(/^(\d{2})(\d)/, "($1) $2")
+      .replace(/(\d{5})(\d)/, "$1-$2")
+      .replace(/(-\d{4})\d+?$/, "$1");
+  }
+
+  function handlePhoneChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const masked = maskPhone(e.target.value);
+    setValue("phone", masked);
   }
   return (
     <section className=" mx-auto rounded-lg px-5">
@@ -122,12 +137,17 @@ export function ConfirmPresenca() {
 
               <div className="flex w-full flex-col items-start justify-start gap-2">
                 <span className="text-start text-lg/3 font-semibold ">
-                  E-mail{" "}
+                  Telefone para contato{" "}
                 </span>
                 <input
-                  className="h-12 w-full rounded-lg p-4 text-start outline-none placeholder:text-sm focus:border focus:border-amber-400"
-                  placeholder="exemplo@teste.com"
-                  {...register("email")}
+                  className="h-12 w-full rounded-lg p-4 text-start outline-none placeholder:text-sm placeholder:uppercase focus:border focus:border-amber-400"
+                  placeholder="(xx) xxxxx-xxxx"
+                  type="tel"
+                  title="Formato: (xx) xxxxx-xxxx"
+                  id="phone"
+                  {...register("phone")}
+                  onChange={handlePhoneChange}
+                  maxLength={15}
                 />
               </div>
             </div>


### PR DESCRIPTION
This pull request updates the contact field in the `ConfirmPresenca` form from email to phone, introduces phone number masking, and adjusts the form's validation and UI accordingly. Below are the most important changes grouped by theme:

### Form Field Update:

* Replaced the `email` field with a `phone` field in the `validationFormSchema` and the form's default values. The `phone` field now requires a non-empty string instead of an email format. (`src/components/form/Presenca.tsx`, [[1]](diffhunk://#diff-4f44df416476ac8f542f95b81cb101ab6c32833142d80d72b73804842272b4ddL16-R16) [[2]](diffhunk://#diff-4f44df416476ac8f542f95b81cb101ab6c32833142d80d72b73804842272b4ddL34-R34)

### Phone Number Handling:

* Added a `maskPhone` function to format phone numbers as `(xx) xxxxx-xxxx` and a `handlePhoneChange` function to apply this mask during input changes. (`src/components/form/Presenca.tsx`, [src/components/form/Presenca.tsxR88-R100](diffhunk://#diff-4f44df416476ac8f542f95b81cb101ab6c32833142d80d72b73804842272b4ddR88-R100))
* Ensured that the phone number is stripped of non-numeric characters before submission by modifying the `handleSubimitForm` function. (`src/components/form/Presenca.tsx`, [src/components/form/Presenca.tsxR73-R74](diffhunk://#diff-4f44df416476ac8f542f95b81cb101ab6c32833142d80d72b73804842272b4ddR73-R74))

### UI Adjustments:

* Updated the form label from "E-mail" to "Telefone para contato" and adjusted the input field to include a placeholder, `type="tel"`, a title for formatting, and a maximum length of 15 characters. (`src/components/form/Presenca.tsx`, [src/components/form/Presenca.tsxL125-R150](diffhunk://#diff-4f44df416476ac8f542f95b81cb101ab6c32833142d80d72b73804842272b4ddL125-R150))